### PR TITLE
integrate change from src-d/ml nn tokenizer

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,7 @@ max-line-length=99
 exclude=
     .git
     doc
+    venv
 inline-quotes="
 import-order-style=appnexus
 application-package-names=sourced.ml.core

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ ENV/
 
 # CI
 .ci
+
+#vscode
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -115,5 +115,4 @@ ENV/
 # CI
 .ci
 
-#vscode
 .vscode

--- a/sourced/ml/core/models/id_splitter.py
+++ b/sourced/ml/core/models/id_splitter.py
@@ -1,4 +1,3 @@
-import logging
 import string
 from typing import Dict, List, Sequence, Tuple
 
@@ -15,7 +14,7 @@ from sourced.ml.core.models.license import DEFAULT_LICENSE
 @register_model
 class IdentifierSplitterBiLSTM(Model):
     """
-    Bidirectionnal LSTM Model. Splits identifiers without need for a conventional pattern.
+    Bidirectional LSTM Model. Splits identifiers without need for a conventional pattern.
     Reference: https://arxiv.org/abs/1805.11651
     """
     NAME = "id_splitter_bilstm"
@@ -27,6 +26,14 @@ class IdentifierSplitterBiLSTM(Model):
     DEFAULT_PADDING = "post"
     DEFAULT_MAPPING = {c: i for i, c in enumerate(string.ascii_lowercase, start=1)}
     DEFAULT_BATCH_SIZE = 4096
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._maxlen = self.DEFAULT_MAXLEN
+        self._padding = self.DEFAULT_PADDING
+        self._mapping = self.DEFAULT_MAPPING
+        self._model = None
+        self._batch_size = self.DEFAULT_BATCH_SIZE
 
     def construct(self, model: "keras.models.Model",
                   maxlen: int = DEFAULT_MAXLEN,
@@ -47,7 +54,6 @@ class IdentifierSplitterBiLSTM(Model):
         self._mapping = mapping
         self._model = model
         self._batch_size = batch_size
-        self._log = logging.getLogger("IdentifierSplitterBiLSTM")
 
         return self
 

--- a/sourced/ml/core/models/id_splitter.py
+++ b/sourced/ml/core/models/id_splitter.py
@@ -1,0 +1,121 @@
+import logging
+import string
+from typing import List, Sequence, Tuple
+
+import keras
+from keras.preprocessing.sequence import pad_sequences
+from modelforge import Model, register_model
+import numpy
+
+from sourced.ml.algorithms.id_splitter.nn_model import (f1score, precision,
+                                                        recall)
+from sourced.ml.models.license import DEFAULT_LICENSE
+
+
+@register_model
+class IdentifierSplitterNN(Model):
+    """
+    Bi-Directionnal LSTM Model. Splits identifiers without need for a conventional pattern.
+    """
+    NAME = "id_splitter_nn"
+    VENDOR = "source{d}"
+    DESCRIPTION = "Weights of the BiLSTM network to split source code identifiers."
+    LICENSE = DEFAULT_LICENSE
+
+    DEFAULT_MAXLEN = 40
+    DEFAULT_PADDING = "post"
+    DEFAULT_MAPPING = None
+
+    def construct(self, model: "keras.models.Model",
+                  maxlen: int = DEFAULT_MAXLEN,
+                  padding: str = DEFAULT_PADDING,
+                  mapping: dict = DEFAULT_MAPPING) -> "IdentifierSplitterNN":
+
+        self._maxlen = maxlen
+        self._padding = padding
+        self._mapping = mapping
+        self._model = model
+        return self
+
+    @property
+    def model(self) -> "keras.models.Model":
+        """
+        Returns the wrapped keras model.
+        """
+        return self._model
+
+    def clear_keras(self):
+        """
+        Clears the keras session used to run the model
+        """
+        keras.backend.clear_session()
+
+    def _generate_tree(self) -> dict:
+        return {
+            "config": self._model.get_config(),
+            "weights": self._model.get_weights(),
+            "mapping": self._mapping,
+            }
+
+    def _load_tree(self, tree: dict):
+        model = keras.models.Model.from_config(tree["config"])
+        model.set_weights(tree["weights"])
+        if "mapping" in tree:
+            self.construct(model, mapping=tree["mapping"])
+        else:
+            self.construct(model)
+
+    def _prepare_single_identifier(self, identifier: str) -> Tuple[numpy.array, str]:
+        if self._mapping is None:
+            self._mapping = {c: i for i, c in enumerate(string.ascii_lowercase, start=1)}
+
+        # Clean identifier
+        clean_id = "".join(char for char in identifier.lower() if char in self._mapping)
+        if len(clean_id) > self._maxlen:
+            clean_id = clean_id[:self._maxlen]
+        logging.info("Preprocessed identifier: {}".format(clean_id))
+        return numpy.array([self._mapping[c] for c in clean_id], dtype="int8"), clean_id
+
+    def prepare_input(self, identifiers: Sequence[str]) -> Tuple[numpy.array, List[str]]:
+        """
+        Prepares input by converting a sequence of identifiers to the corresponding
+        ascii code 2D-array and the list of lowercase cleaned identifiers.
+        """
+        processed_ids = []
+        clean_ids = []
+        for identifier in identifiers:
+            feat, clean_id = self._prepare_single_identifier(identifier)
+            processed_ids.append(feat)
+            clean_ids.append(clean_id)
+
+        processed_ids = pad_sequences(processed_ids, maxlen=self._maxlen, padding=self._padding)
+        return processed_ids, clean_ids
+
+    def load_model_file(self, path: str):
+        """
+        Loads a compatible Keras model file. Used for compatibility.
+        """
+        self._model = keras.models.load_model(path, custom_objects={"precision": precision,
+                                                                    "recall": recall,
+                                                                    "f1score": f1score})
+
+    def split(self, identifiers: Sequence[str]) -> List[str]:
+        """
+        Splits a lists of identifiers using the model.
+        """
+        feats, clean_ids = self.prepare_input(identifiers)
+        output = self._model.predict(feats, batch_size=4096)
+        output = numpy.round(output)[:, :, 0]
+        splitted_ids = []
+        for clean_id, id_output in zip(clean_ids, output):
+            splitted_id = ""
+            for char, label in zip(clean_id, id_output):
+                if label == 1:
+                    splitted_ids.append(splitted_id)
+                    splitted_id = ""
+                splitted_id += char
+            splitted_ids.append(splitted_id)
+        return splitted_ids
+
+    def __del__(self):
+        self.clear_keras()

--- a/sourced/ml/core/models/id_splitter.py
+++ b/sourced/ml/core/models/id_splitter.py
@@ -6,9 +6,10 @@ import keras
 from keras.preprocessing.sequence import pad_sequences
 from modelforge import Model, register_model
 import numpy
-from sourced.ml.algorithms.id_splitter.nn_model import (f1score, precision,
-                                                        recall)
-from sourced.ml.models.license import DEFAULT_LICENSE
+
+from sourced.ml.core.algorithms.id_splitter.nn_model import (f1score, precision,
+                                                             recall)
+from sourced.ml.core.models.license import DEFAULT_LICENSE
 
 
 @register_model

--- a/sourced/ml/core/models/id_splitter.py
+++ b/sourced/ml/core/models/id_splitter.py
@@ -6,7 +6,6 @@ import keras
 from keras.preprocessing.sequence import pad_sequences
 from modelforge import Model, register_model
 import numpy
-
 from sourced.ml.algorithms.id_splitter.nn_model import (f1score, precision,
                                                         recall)
 from sourced.ml.models.license import DEFAULT_LICENSE

--- a/sourced/ml/core/models/id_splitter.py
+++ b/sourced/ml/core/models/id_splitter.py
@@ -1,6 +1,6 @@
 import logging
 import string
-from typing import List, Sequence, Tuple
+from typing import Dict, List, Sequence, Tuple
 
 from modelforge import Model, register_model
 import numpy
@@ -15,7 +15,7 @@ from sourced.ml.core.models.license import DEFAULT_LICENSE
 @register_model
 class IdentifierSplitterBiLSTM(Model):
     """
-    Bi-Directionnal LSTM Model. Splits identifiers without need for a conventional pattern.
+    Bidirectionnal LSTM Model. Splits identifiers without need for a conventional pattern.
     Reference: https://arxiv.org/abs/1805.11651
     """
     NAME = "id_splitter_bilstm"
@@ -31,13 +31,13 @@ class IdentifierSplitterBiLSTM(Model):
     def construct(self, model: "keras.models.Model",
                   maxlen: int = DEFAULT_MAXLEN,
                   padding: str = DEFAULT_PADDING,
-                  mapping: dict = DEFAULT_MAPPING,
-                  batch_size: int = DEFAULT_BATCH_SIZE) -> "IdentifierSplitterNN":
+                  mapping: Dict[str, int] = DEFAULT_MAPPING,
+                  batch_size: int = DEFAULT_BATCH_SIZE) -> "IdentifierSplitterBiLSTM":
         """
         :param model: keras model used for identifier splitting.
         :param maxlen: maximum length of input identifers.
         :param padding: where to pad the identifiers of length < maxlen. Can be "left" or "right".
-        :param mapping: { str: int } mapping of characters to integers.
+        :param mapping: mapping of characters to integers.
         :param batch_size: batch size of input data fed to the model.
         :return: BiLSTM based source code identifier splitter.
         """
@@ -81,7 +81,6 @@ class IdentifierSplitterBiLSTM(Model):
                        padding=tree["padding"], mapping=tree["mapping"])
 
     def _prepare_single_identifier(self, identifier: str) -> Tuple[numpy.array, str]:
-
         # Clean identifier
         clean_id = "".join(char for char in identifier.lower() if char in self._mapping)
         if len(clean_id) > self._maxlen:
@@ -91,7 +90,7 @@ class IdentifierSplitterBiLSTM(Model):
 
     def prepare_input(self, identifiers: Sequence[str]) -> Tuple[numpy.array, List[str]]:
         """
-        Prepares input by converting a sequence of identifiers to the corresponding
+        Prepare input by converting a sequence of identifiers to the corresponding
         ascii code 2D-array and the list of lowercase cleaned identifiers.
         """
         processed_ids = []

--- a/sourced/ml/core/tests/models.py
+++ b/sourced/ml/core/tests/models.py
@@ -11,6 +11,7 @@ COOCC = join(_models_path, "coocc.asdf")
 COOCC_DF = join(_models_path, "coocc_df.asdf")
 UAST = join(_models_path, "uast.asdf")
 TOPICS = join(_models_path, "topics.asdf")
+ID_SPLITTER_RNN = join(_models_path, "id_splitter_rnn.asdf")
 
 DATA_DIR_SOURCE = join(_root, "source")
 SOURCE_FILENAME = "example"

--- a/sourced/ml/core/tests/models.py
+++ b/sourced/ml/core/tests/models.py
@@ -11,7 +11,7 @@ COOCC = join(_models_path, "coocc.asdf")
 COOCC_DF = join(_models_path, "coocc_df.asdf")
 UAST = join(_models_path, "uast.asdf")
 TOPICS = join(_models_path, "topics.asdf")
-ID_SPLITTER_RNN = join(_models_path, "id_splitter_rnn.asdf")
+ID_SPLITTER_BILSTM = join(_models_path, "id_splitter_bilstm.asdf")
 
 DATA_DIR_SOURCE = join(_root, "source")
 SOURCE_FILENAME = "example"

--- a/sourced/ml/core/tests/test_id_splitter_nn_model.py
+++ b/sourced/ml/core/tests/test_id_splitter_nn_model.py
@@ -1,10 +1,11 @@
 import string
+import tempfile
 import unittest
 
 import numpy
 
 from sourced.ml.core.tests import has_tensorflow
-
+from sourced.ml.tests.models import ID_SPLITTER_RNN
 
 class MetricsTests(unittest.TestCase):
     @unittest.skipIf(not has_tensorflow(), "Tensorflow is not installed.")

--- a/sourced/ml/core/tests/test_id_splitter_nn_model.py
+++ b/sourced/ml/core/tests/test_id_splitter_nn_model.py
@@ -3,9 +3,9 @@ import tempfile
 import unittest
 
 import numpy
-from sourced.ml.tests.models import ID_SPLITTER_RNN
 
 from sourced.ml.core.tests import has_tensorflow
+from sourced.ml.core.tests.models import ID_SPLITTER_RNN
 
 
 class MetricsTests(unittest.TestCase):
@@ -57,7 +57,7 @@ class ModelsTests(unittest.TestCase):
 @unittest.skipIf(not has_tensorflow(), "Tensorflow is not installed.")
 class NNModelTest(unittest.TestCase):
     def setUp(self):
-        from sourced.ml.models.id_splitter import IdentifierSplitterNN
+        from sourced.ml.core.models.id_splitter import IdentifierSplitterNN
         self.test_X = ["networkSocket", "variablename", "loadfile", "blahblah", "foobar"]
         self.test_y = ["network", "socket", "variable",
                        "name", "load", "file", "blah", "blah", "foobar"]

--- a/sourced/ml/core/tests/test_id_splitter_nn_model.py
+++ b/sourced/ml/core/tests/test_id_splitter_nn_model.py
@@ -3,9 +3,10 @@ import tempfile
 import unittest
 
 import numpy
+from sourced.ml.tests.models import ID_SPLITTER_RNN
 
 from sourced.ml.core.tests import has_tensorflow
-from sourced.ml.tests.models import ID_SPLITTER_RNN
+
 
 class MetricsTests(unittest.TestCase):
     @unittest.skipIf(not has_tensorflow(), "Tensorflow is not installed.")
@@ -52,6 +53,7 @@ class ModelsTests(unittest.TestCase):
         self.assertEqual(self.model_cnn.get_weights()[0].shape, (self.n_uniq+1, self.n_uniq+1))
         self.assertTrue(self.model_cnn.uses_learning_phase)
 
+
 @unittest.skipIf(not has_tensorflow(), "Tensorflow is not installed.")
 class NNModelTest(unittest.TestCase):
     def setUp(self):
@@ -70,6 +72,7 @@ class NNModelTest(unittest.TestCase):
             self.id_splitter.save(tmpdir + "/model.asdf", series="id-splitter-nn")
             self.id_splitter.load(tmpdir + "/model.asdf")
         self.assertEqual(self.id_splitter.split(self.test_X), self.test_y)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sourced/ml/core/tests/test_id_splitter_nn_model.py
+++ b/sourced/ml/core/tests/test_id_splitter_nn_model.py
@@ -5,7 +5,7 @@ import unittest
 import numpy
 
 from sourced.ml.core.tests import has_tensorflow
-from sourced.ml.core.tests.models import ID_SPLITTER_RNN
+from sourced.ml.core.tests.models import ID_SPLITTER_BILSTM
 
 
 class MetricsTests(unittest.TestCase):
@@ -57,12 +57,12 @@ class ModelsTests(unittest.TestCase):
 @unittest.skipIf(not has_tensorflow(), "Tensorflow is not installed.")
 class NNModelTest(unittest.TestCase):
     def setUp(self):
-        from sourced.ml.core.models.id_splitter import IdentifierSplitterNN
+        from sourced.ml.core.models.id_splitter import IdentifierSplitterBiLSTM
         self.test_X = ["networkSocket", "variablename", "loadfile", "blahblah", "foobar"]
         self.test_y = ["network", "socket", "variable",
                        "name", "load", "file", "blah", "blah", "foobar"]
-        self.id_splitter = IdentifierSplitterNN()
-        self.id_splitter.load(ID_SPLITTER_RNN)
+        self.id_splitter = IdentifierSplitterBiLSTM()
+        self.id_splitter.load(ID_SPLITTER_BILSTM)
 
     def test_load_and_run_model(self):
         self.assertEqual(self.id_splitter.split(self.test_X), self.test_y)

--- a/sourced/ml/core/tests/test_id_splitter_nn_model.py
+++ b/sourced/ml/core/tests/test_id_splitter_nn_model.py
@@ -52,6 +52,24 @@ class ModelsTests(unittest.TestCase):
         self.assertEqual(self.model_cnn.get_weights()[0].shape, (self.n_uniq+1, self.n_uniq+1))
         self.assertTrue(self.model_cnn.uses_learning_phase)
 
+@unittest.skipIf(not has_tensorflow(), "Tensorflow is not installed.")
+class NNModelTest(unittest.TestCase):
+    def setUp(self):
+        from sourced.ml.models.id_splitter import IdentifierSplitterNN
+        self.test_X = ["networkSocket", "variablename", "loadfile", "blahblah", "foobar"]
+        self.test_y = ["network", "socket", "variable",
+                       "name", "load", "file", "blah", "blah", "foobar"]
+        self.id_splitter = IdentifierSplitterNN()
+        self.id_splitter.load(ID_SPLITTER_RNN)
+
+    def test_load_and_run_model(self):
+        self.assertEqual(self.id_splitter.split(self.test_X), self.test_y)
+
+    def test_save_model(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.id_splitter.save(tmpdir + "/model.asdf", series="id-splitter-nn")
+            self.id_splitter.load(tmpdir + "/model.asdf")
+        self.assertEqual(self.id_splitter.split(self.test_X), self.test_y)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adding the NN id splitter to src-d/ml-core. PR migrated from https://github.com/src-d/ml/pull/405
Note that I separated original PR into two. This one only adds the neural network model code, but do not modifiy the `tokenparser` so it can be merged before https://github.com/src-d/models/pull/18